### PR TITLE
feat: Add MCP-specific headers to help Claude web recognition

### DIFF
--- a/server.js
+++ b/server.js
@@ -154,6 +154,11 @@ app.get('/api/mcp/sse', async (req, res) => {
 
 // MCP Server main endpoint
 app.all('/api/mcp/server', async (req, res) => {
+  // Add MCP-specific headers to help Claude web recognize this as MCP server
+  res.setHeader("X-MCP-Version", "2024-11-05");
+  res.setHeader("X-MCP-Server", "BRAINLOOP MCP Server");
+  res.setHeader("X-MCP-Protocol", "json-rpc-2.0");
+  res.setHeader("Content-Type", "application/json");
   const userAgent = req.headers['user-agent'] || 'unknown';
   const origin = req.headers.origin || '';
   const referer = req.headers.referer || '';


### PR DESCRIPTION
## Problem
Claude web is not properly recognizing our MCP server and falling back to root path requests instead of using the configured MCP endpoints.

## Solution
Add MCP-specific headers to help Claude web identify this as a proper MCP server:
- X-MCP-Version: 2024-11-05
- X-MCP-Server: BRAINLOOP MCP Server  
- X-MCP-Protocol: json-rpc-2.0
- Content-Type: application/json

## Based on
Claude Code insight that web uses different discovery mechanism than desktop and expects specific protocol signals.

## Testing
- [ ] Test Configure button in Claude web
- [ ] Verify MCP endpoints are used instead of root path
- [ ] Check OAuth flow triggers properly